### PR TITLE
ci: Comment out additional Python versions in CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
           - "macos-latest"
         python-version:
           - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
+          # - "3.11"  # Uncomment these when open sourcing
+          # - "3.12"
+          # - "3.13"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 


### PR DESCRIPTION
Comment out Python versions 3.11, 3.12, and 3.13 for future use.