### PR TITLE
fix: ^ and $ may present in regex parameter

### DIFF
--- a/src/gimkit/schemas.py
+++ b/src/gimkit/schemas.py
@@ -150,9 +150,9 @@ class MaskedTag:
 
         # 4. Validate regex if provided
         if isinstance(self.regex, str):
-            if "^" in self.regex or "$" in self.regex:
+            if self.regex.startswith("^") or self.regex.endswith("$"):
                 raise ValueError(
-                    "regex should not contain ^ or $, "
+                    "regex should not start with ^ or end with $, "
                     "as it will be used within a larger regex pattern."
                 )
             if self.regex.startswith("/") or self.regex.endswith("/"):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -75,7 +75,7 @@ def test_masked_tag_init_invalid():
 
 
 def test_masked_tag_init_with_regex():
-    with pytest.raises(ValueError, match=r"regex should not contain \^ or \$"):
+    with pytest.raises(ValueError, match=r"regex should not start with \^ or end with \$"):
         MaskedTag(regex="^abc$")
     with pytest.raises(ValueError, match="regex should not be an empty string"):
         MaskedTag(regex="")


### PR DESCRIPTION
^ and $ may present in regex parameter, for example: `r"(?:[^.!?]+[.!?]){4}")`